### PR TITLE
Minor syntax fix to README. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For Windows install instructions, see OLD\_README.
 ## Usage
 
 Wherever you need a debugger, simply:
+
 ```ruby
 require 'debugger'; debugger
 ```


### PR DESCRIPTION
Syntax highlighting in fenced code blocks only seems to work when the block is a paragraph. Otherwise, the language identifier (`ruby`, here) is included as if it were part of the code.

---
### Previously

Wherever you need a debugger, simply:

``` ruby
require 'debugger'; debugger
```

---
### Fixed

Wherever you need a debugger, simply:

``` ruby
require 'debugger'; debugger
```
