### PR TITLE
Support colon-delimited include paths in command-line front-end

### DIFF
--- a/bin/rdebug
+++ b/bin/rdebug
@@ -200,7 +200,7 @@ EOB
       options.host = host
     end
     opts.on('-I', '--include PATH', String, 'Add PATH to $LOAD_PATH') do |path|
-      $LOAD_PATH.unshift(path)
+      $LOAD_PATH.unshift(*path.split(':'))
     end
     opts.on('--no-control', 'Do not automatically start control thread') do
       options.control = false

--- a/test/tdebug.rb
+++ b/test/tdebug.rb
@@ -114,7 +114,7 @@ EOB
     options.nx = true
   end
   opts.on("-I", "--include PATH", String, "Add PATH to $LOAD_PATH") do |path|
-    $LOAD_PATH.unshift(path)
+    $LOAD_PATH.unshift(*path.split(':'))
   end
   opts.on("-r", "--require SCRIPT", String,
           "Require the library, before executing your script") do |name|


### PR DESCRIPTION
Similar to the Ruby -I command, rdebug should support multiple load paths
separated by colons.
