### PR TITLE
Non-integer number of lines when trying to display the source on breakpoint

### DIFF
--- a/lib/ruby-debug/commands/list.rb
+++ b/lib/ruby-debug/commands/list.rb
@@ -44,7 +44,7 @@ module Debugger
           e = b + listsize - 1
         end
       end
-      @state.previous_line = display_list(b, e, @state.file, @state.line)
+      @state.previous_line = display_list(b.to_i, e, @state.file, @state.line)
     end
 
     class << self


### PR DESCRIPTION
Certain settings of the .rdebugrc file, like in my case this:

```
set listsize 25
```

Caused exception to appear when invoking the debugger:

```
INTERNAL ERROR!!! undefined method `upto' for (307/2):Rational
vendor/ruby/1.9.1/gems/debugger-1.1.3/lib/ruby-debug/commands/list.rb:79:in `display_list'
vendor/ruby/1.9.1/gems/debugger-1.1.3/lib/ruby-debug/commands/list.rb:47:in `execute'
```

This commit fixes the error.
