### PR TITLE
add license information to the gemspec

### DIFF
--- a/debugger.gemspec
+++ b/debugger.gemspec
@@ -26,4 +26,5 @@ handling, bindings for stack frames among other things.
   s.add_development_dependency 'rake-compiler', '~> 0.8.0'
   s.add_development_dependency 'minitest', '~> 2.12.1'
   s.add_development_dependency 'mocha', '~> 0.13.0'
+  s.license = "BSD"
 end


### PR DESCRIPTION
This way you can find this information with the rubygems.org API
