### PR TITLE
Fix warning 'already initialized constant SEPARATOR' [#73]

### DIFF
--- a/lib/ruby-debug/printers/base.rb
+++ b/lib/ruby-debug/printers/base.rb
@@ -4,7 +4,7 @@ module Printers
     class MissedPath < StandardError; end
     class MissedArgument < StandardError; end
 
-    SEPARATOR = "."
+    SEPARATOR = "." unless const_defined?("SEPARATOR")
 
     def type
       self.class.name.split("::").last.downcase


### PR DESCRIPTION
Should fix #73
