### PR TITLE
Fix missing unformatted output [#75]

### DIFF
--- a/lib/debugger/test/test_interface.rb
+++ b/lib/debugger/test/test_interface.rb
@@ -12,8 +12,8 @@ class TestInterface < Debugger::Interface
     @readline_support = false
   end
 
-  def errmsg(*args)
-    @error_queue << format(args)
+  def errmsg(value)
+    @error_queue << value
   end
 
   def read_command(*args)
@@ -25,8 +25,8 @@ class TestInterface < Debugger::Interface
     result.is_a?(Proc) ? result.call : result
   end
 
-  def print(*args)
-    @output_queue << format(args)
+  def print(value)
+    @output_queue << value
   end
 
   def confirm(message)
@@ -58,13 +58,4 @@ class TestInterface < Debugger::Interface
     ].join("\n")
   end
 
-  private
-
-    def format(args)
-      if args.size > 1
-        args.first % args[1..-1]
-      else
-        args.first
-      end
-    end
 end

--- a/lib/ruby-debug/commands/eval.rb
+++ b/lib/ruby-debug/commands/eval.rb
@@ -110,7 +110,7 @@ module Debugger
         vals = debug_eval(@match.post_match, b)
         if vals.is_a?(Array)
           vals = vals.map{|item| item.to_s}
-          print "%s\n", columnize(vals, self.class.settings[:width])
+          print "#{columnize(vals, self.class.settings[:width])}\n"
         else
           PP.pp(vals, out)
           print out.string
@@ -148,7 +148,7 @@ module Debugger
         vals = debug_eval(@match.post_match, b)
         if vals.is_a?(Array)
           vals = vals.map{|item| item.to_s}
-          print "%s\n", columnize(vals.sort!, self.class.settings[:width])
+          print "#{columnize(vals.sort!, self.class.settings[:width])}\n"
         else
           PP.pp(vals, out)
           print out.string

--- a/lib/ruby-debug/commands/info.rb
+++ b/lib/ruby-debug/commands/info.rb
@@ -143,11 +143,9 @@ item. If \'verbose\' is given then the entire stack frame is shown.'],
         print "Num Enb What\n"
         brkpts.each do |b|
           if b.expr.nil?
-            print "%3d %s   at %s:%s\n", 
-            b.id, (b.enabled? ? 'y' : 'n'), b.source, b.pos
+            print("%3d %s   at %s:%s\n" % [b.id, (b.enabled? ? 'y' : 'n'), b.source, b.pos])
           else
-            print "%3d %s   at %s:%s if %s\n", 
-            b.id, (b.enabled? ? 'y' : 'n'), b.source, b.pos, b.expr
+            print("%3d %s   at %s:%s if %s\n" % [b.id, (b.enabled? ? 'y' : 'n'), b.source, b.pos, b.expr])
           end
           hits = b.hit_count
           if hits > 0
@@ -170,8 +168,7 @@ item. If \'verbose\' is given then the entire stack frame is shown.'],
         print "Num Enb Expression\n"
         n = 1
         for d in @state.display
-          print "%3d: %s  %s\n", n, (d[0] ? 'y' : 'n'), d[1] if
-            d[0] != nil
+          print("%3d: %s  %s\n" % [n, (d[0] ? 'y' : 'n'), d[1]]) if d[0] != nil
           n += 1
         end
       else
@@ -202,17 +199,17 @@ item. If \'verbose\' is given then the entire stack frame is shown.'],
         LineCache::cache(file, Command.settings[:reload_source_on_change])
       end
       
-      print "File %s", file
+      print("File #{file}")
       path = LineCache.path(file)
       if %w(all basic path).member?(subcmd.name) and path != file
-        print " - %s\n", path 
+        print(" - #{path}\n")
       else
         print "\n"
       end
 
       if %w(all basic lines).member?(subcmd.name)
         lines = LineCache.size(file)
-        print "\t %d lines\n", lines if lines
+        print("\t #{lines} lines\n") if lines
       end
 
       if %w(all breakpoints).member?(subcmd.name)
@@ -225,10 +222,10 @@ item. If \'verbose\' is given then the entire stack frame is shown.'],
 
       if %w(all mtime).member?(subcmd.name)
         stat = LineCache.stat(file)
-        print "\t%s\n", stat.mtime if stat
+        print("\t#{stat.mtime}\n") if stat
       end
       if %w(all sha1).member?(subcmd.name)
-        print "\t%s\n", LineCache.sha1(file)
+        print("\t#{LineCache.sha1(file)}\n")
       end
     end
     
@@ -238,13 +235,13 @@ item. If \'verbose\' is given then the entire stack frame is shown.'],
       files.uniq.sort.each do |file|
         stat = LineCache::stat(file)
         path = LineCache::path(file)
-        print "File %s", file
+        print("File #{file}")
         if path and path != file
-          print " - %s\n", path 
+          print " - #{path}\n"
         else
           print "\n"
         end
-        print "\t%s\n", stat.mtime if stat
+        print "\t#{stat.mtime}\n" if stat
       end
     end
     
@@ -262,7 +259,7 @@ item. If \'verbose\' is given then the entire stack frame is shown.'],
         errmsg "info line not available here.\n"
         return 
       end
-      print "Line %d of \"%s\"\n",  @state.line, @state.file
+      print "Line #{@state.line} of \"#{@state.file}\"\n"
     end
     
     def info_locals(*args)
@@ -310,7 +307,7 @@ item. If \'verbose\' is given then the entire stack frame is shown.'],
       when :catchpoint
         print("It stopped at a catchpoint.\n")
       else
-        print "unknown reason: %s\n" % @state.context.stop_reason.to_s
+        print "unknown reason: #{@state.context.stop_reason.to_s}\n"
       end
     end
     

--- a/lib/ruby-debug/processor.rb
+++ b/lib/ruby-debug/processor.rb
@@ -177,8 +177,7 @@ module Debugger
       file = CommandProcessor.canonic_file(file)
       unless file == @last_file and @last_line == line and
           Command.settings[:tracing_plus]
-        print "Tracing(%d):%s:%s %s",
-        context.thnum, file, line, Debugger.line_at(file, line)
+        print("Tracing(%d):%s:%s %s" % [context.thnum, file, line, Debugger.line_at(file, line)])
         @last_file = file
         @last_line = line
       end


### PR DESCRIPTION
I.e. fixed all "%s", "%d", etc. outputs instead of real values.
