### PR TITLE
Fixes some order dependent failures in test suite.

### DIFF
--- a/test/eval_test.rb
+++ b/test/eval_test.rb
@@ -29,9 +29,11 @@ describe "Eval Command" do
     end
 
     it "must not eval the expression if no matching command is found if toogled" do
-      enter 'set noautoeval', '[5,6,7].inject(&:+)'
-      debug_file 'eval'
-      check_output_doesnt_include "18"
+      temporary_change_hash_value(Debugger::Command.settings, :autoeval, false) do
+        enter '[5,6,7].inject(&:+)'
+        debug_file 'eval'
+        check_output_doesnt_include "18"
+      end
     end
   end
 

--- a/test/finish_test.rb
+++ b/test/finish_test.rb
@@ -38,6 +38,8 @@ describe "Finish Command" do
 
 
   describe "Post Mortem" do
+    temporary_change_hash_value(Debugger::Command.settings, :autoeval, false)
+
     it "must not work in post-mortem mode" do
       enter 'cont', 'finish'
       debug_file "post_mortem"

--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -62,9 +62,11 @@ describe "List Command" do
     end
 
     it "must not show the surronding lines by default when autolist is toggled" do
-      enter 'set noautolist', 'break 5', 'cont'
-      debug_file 'list'
-      check_output_doesnt_include "[4, 6] in #{fullpath('list')}", "4  4", "=> 5  5", "6  6"
+      temporary_change_hash_value(Debugger::Command.settings, :autolist, false) do
+        enter 'break 5', 'cont'
+        debug_file 'list'
+        check_output_doesnt_include "[4, 6] in #{fullpath('list')}", "4  4", "=> 5  5", "6  6"
+      end
     end
   end
 


### PR DESCRIPTION
I just found this issue. I accidentally introduced it in pull request #72. This pull request should fix it. To reproduce execute just the eval test a few times, it will eventually fail.

```
rake TEST=test/eval_test.rb
```

This is because autoeval and autolist were being unset and never turned back to their default state.
