### PR TITLE
bump ruby_core_source dependency

### DIFF
--- a/debugger.gemspec
+++ b/debugger.gemspec
@@ -20,7 +20,7 @@ handling, bindings for stack frames among other things.
   s.extensions << "ext/ruby_debug/extconf.rb"
   s.executables = ["rdebug"]
   s.add_dependency "columnize", ">= 0.3.1"
-  s.add_dependency "debugger-ruby_core_source", '~> 1.2.1'
+  s.add_dependency "debugger-ruby_core_source", '~> 1.2.3'
   s.add_dependency "debugger-linecache", '~> 1.2.0'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
   s.add_development_dependency 'rake-compiler', '~> 0.8.0'


### PR DESCRIPTION
We need this to support the latest ruby patchlevels, which were introduced here:
http://www.ruby-lang.org/en/news/2013/06/27/hostname-check-bypassing-vulnerability-in-openssl-client-cve-2013-4073/
