### PR TITLE
Gitignore generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ vendor/bundle
 .bundle
 
 lib/ruby_debug.bundle
+lib/ruby_debug.so
+
 ext/ruby_debug/breakpoint.c
 ext/ruby_debug/ruby_debug.c
 ext/ruby_debug/ruby_debug.h


### PR DESCRIPTION
Because it's not part of the source code, because it won't get accidentally committed by contributors...
