### PR TITLE
fix show command

### DIFF
--- a/lib/ruby-debug/commands/show.rb
+++ b/lib/ruby-debug/commands/show.rb
@@ -181,8 +181,8 @@ show history size -- Show the size of the command history"],
     end
 
     def execute
-      if not @match[1]
-        subcommands = subcmd.map { |s| "show #{s.name} -- #{s.short_help}" }.join("\n")
+      if !@match[1]
+        subcommands = Subcommands.map { |s| "show #{s.name} -- #{s.short_help}" }.join("\n")
         print pr("show.errors.no_subcommand", subcommands: subcommands)
       else
         args = @match[1].split(/[ \t]+/)

--- a/test/show_test.rb
+++ b/test/show_test.rb
@@ -23,6 +23,13 @@ describe "Show Command" do
   describe "args" do
     temporary_change_hash_value(Debugger::Command.settings, :argv, %w{foo bar})
 
+    it "when no args givenmust show args" do
+      Debugger.send(:remove_const, "RDEBUG_SCRIPT") if Debugger.const_defined?("RDEBUG_SCRIPT")
+      enter 'show'
+      debug_file 'show'
+      check_output_includes /\"show\" must be followed by the name of an show command/
+    end
+
     it "must show args" do
       Debugger.send(:remove_const, "RDEBUG_SCRIPT") if Debugger.const_defined?("RDEBUG_SCRIPT")
       enter 'show args'


### PR DESCRIPTION
`show` command is broken on master after https://github.com/cldwalker/debugger/commit/d7f5ea7cddf9d4611cdd8e795522f3433ad02e0c

stacktrace

``` ruby
rdb:1) show
INTERNAL ERROR!!! undefined local variable or method `subcmd' for #<Debugger::ShowCommand:0x007ffeb0f4bf80>
        /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/debugger-1.6.0/lib/ruby-debug/commands/show.rb:185:in `execute'
        /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/debugger-1.6.0/lib/ruby-debug/processor.rb:279:in `one_cmd'
        /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/debugger-1.6.0/lib/ruby-debug/processor.rb:265:in `block (2 levels) in process_commands'
        /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/debugger-1.6.0/lib/ruby-debug/processor.rb:264:in `each'
        /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/debugger-1.6.0/lib/ruby-debug/processor.rb:264:in `block in process_commands'
        /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/debugger-1.6.0/lib/ruby-debug/processor.rb:257:in `catch'
        /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/debugger-1.6.0/lib/ruby-debug/processor.rb:257:in `process_commands'
        /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/debugger-1.6.0/lib/ruby-debug/processor.rb:190:in `at_line'
        (eval):5:in `block in at_line'
        <internal:prelude>:10:in `synchronize'
```

This patch fixes the problem and add a regression test.
