### PR TITLE
Var instance command regexp

### DIFF
--- a/lib/ruby-debug/commands/variables.rb
+++ b/lib/ruby-debug/commands/variables.rb
@@ -110,7 +110,7 @@ module Debugger
   class VarInstanceCommand < Command # :nodoc:
     def regexp
       # id will be read as first match, name as post match
-      /^\s*v(?:ar)?\s+i(?:ns(?:tance)?)?\s*((?:[\\+-]0x)[\dabcdef]+)?/
+      /^\s*v(?:ar)?\s+i(?:ns(?:tance)?)?\s*(?:((?:[\\+-]0x)[\dabcdef]+)|\s|$)/
     end
 
     def execute

--- a/test/variables_test.rb
+++ b/test/variables_test.rb
@@ -83,6 +83,12 @@ describe "Variables Command" do
       check_output_includes /@inst_a = 1\n@inst_b = 2/
     end
 
+    it "must not accept 'v insv' as shortcut for 'v ins v'" do
+      enter 'break 25', 'cont', 'v insv'
+      debug_file 'variables'
+      check_output_doesnt_include /@inst_a = 1\n@inst_b = 2/
+    end
+
     it "must be able to use i as a shortcut" do
       enter 'break 25', 'cont', 'v i v'
       debug_file 'variables'


### PR DESCRIPTION
I'm trying to make use of debugger for RubyMine debugging (using debugger-xml).
And we need at least two changed in VarInstanceCommand
- "v i" shortcut for "var instance"
- 'v inspect' should not be treated as 'v ins pect' (to be able to add inspect command to debugger-xml)
