### PR TITLE
Bump version of debugger-ruby_core_source.

### DIFF
--- a/debugger.gemspec
+++ b/debugger.gemspec
@@ -20,7 +20,7 @@ handling, bindings for stack frames among other things.
   s.extensions << "ext/ruby_debug/extconf.rb"
   s.executables = ["rdebug"]
   s.add_dependency "columnize", ">= 0.3.1"
-  s.add_dependency "debugger-ruby_core_source", '~> 1.2.3'
+  s.add_dependency "debugger-ruby_core_source", '~> 1.2.4'
   s.add_dependency "debugger-linecache", '~> 1.2.0'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
   s.add_development_dependency 'rake-compiler', '~> 0.8.0'


### PR DESCRIPTION
This is so we can pull in the source for the latest releases of 1.9.3 and 2.0.0.
