### PR TITLE
Add information about remote debugging to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Most commands are described in rdebug's man page
 
     $ gem install gem-man
     $ man rdebug
+    
+To debug a separate process remotely (such as unicorn) try:
+
+```ruby
+  Debugger.wait_connection = true
+  Debugger.start_remote
+  debugger
+```
+
+Then you can do
+
+     $ rdebug -c
 
 ### More documentation
 


### PR DESCRIPTION
Since I didn't have man rdebug on my machine, it took me a bit of digging
to find how to handle doing this, or if it was even possible. All of the google results for 'ruby remote debug' were garbage, so I couldn't find the exact invocation. 

It seems like important information that should be surfaced. 
