### PR TITLE
Depend on latest ruby_core_source for 1.9.3-p547

### DIFF
--- a/debugger.gemspec
+++ b/debugger.gemspec
@@ -20,7 +20,7 @@ handling, bindings for stack frames among other things.
   s.extensions << "ext/ruby_debug/extconf.rb"
   s.executables = ["rdebug"]
   s.add_dependency "columnize", ">= 0.3.1"
-  s.add_dependency "debugger-ruby_core_source", '~> 1.3.2'
+  s.add_dependency "debugger-ruby_core_source", '~> 1.3.5'
   s.add_dependency "debugger-linecache", '~> 1.2.0'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
   s.add_development_dependency 'rake-compiler', '~> 0.8.0'


### PR DESCRIPTION
Bump ruby_core_source dependency to support ruby-1.9.3-p547
